### PR TITLE
add tree diameter inputs to filter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,7 +117,6 @@ export function App() {
           max_lat: maxLatToUse,
           max_lng: maxLngToUse,
         }
-
     const updatedUrlParameters = {
       ...extentParameters,
       cities: newParameters.cities?.length
@@ -126,6 +125,8 @@ export function App() {
       common_species: newParameters.common_species?.length
         ? newParameters.common_species
         : existingSearchParameters.getAll('common_species'),
+      min_dbh: newParameters.min_dbh || existingSearchParameters.getAll('min_dbh'),
+      max_dbh: newParameters.max_dbh || existingSearchParameters.getAll('max_dbh'),
     } as SharableUrlParameters
     // react router's setSearchParams still works and is used because
     // it doesnt cacuse the app to refresh like writing

--- a/src/components/SidebarLeft.tsx
+++ b/src/components/SidebarLeft.tsx
@@ -14,6 +14,7 @@ import { ReactComponent as CifLogo } from '../assets/logo.svg'
 import { SpeciesFilter } from './SpeciesFilter'
 import { themeMui } from '../globalStyles/themeMui'
 import { DownloadModalContent } from './DownloadModalContent'
+import { TreeDiameterFilter } from './TreeDiameterFilter'
 
 const SideBarWrapper = styled('div')`
   padding: ${themeMui.spacing(3)};
@@ -141,6 +142,10 @@ export function Sidebar({
                     clearSearchParameterTypeAndUpdateTrees={clearSearchParameterTypeAndUpdateTrees}
                     setSearchParametersAndUpdateTrees={setSearchParametersAndUpdateTrees}
                     commonSpecies={commonSpecies}
+                  />
+                  <TreeDiameterFilter
+                    clearSearchParameterTypeAndUpdateTrees={clearSearchParameterTypeAndUpdateTrees}
+                    setSearchParametersAndUpdateTrees={setSearchParametersAndUpdateTrees}
                   />
                 </div>
 

--- a/src/components/SpeciesFilter.tsx
+++ b/src/components/SpeciesFilter.tsx
@@ -130,6 +130,7 @@ export function SpeciesFilter({
       </RowAlignItemsCenter>
       <Collapse in={isSpeciesFilterExpanded}>
         <Autocomplete
+          sx={{ marginLeft: '24px' }}
           multiple
           options={commonSpecies}
           getOptionLabel={(option) => option}

--- a/src/components/TreeDiameterFilter.tsx
+++ b/src/components/TreeDiameterFilter.tsx
@@ -1,0 +1,91 @@
+import { Checkbox, Collapse, TextField } from '@mui/material'
+import { ChangeEvent, useState } from 'react'
+
+import { ButtonExpandCollapse } from './ButtonExpandCollapse'
+import { CifFormControlLabel, CifFormControlLabelIndented } from './customMuiFormComponents'
+import { RowAlignItemsCenter } from './containers'
+import { SetSearchParametersAndUpdateTrees, SharableUrlParameters } from '../types/topLevelAppTypes'
+
+interface TreeDiameterFilterProps {
+  clearSearchParameterTypeAndUpdateTrees: (paramName: string) => void
+  setSearchParametersAndUpdateTrees: SetSearchParametersAndUpdateTrees
+}
+
+interface handleSizeChangeProps {
+  event: ChangeEvent<HTMLInputElement>
+  urlParamName: string
+}
+
+export function TreeDiameterFilter({
+  clearSearchParameterTypeAndUpdateTrees,
+  setSearchParametersAndUpdateTrees,
+}: TreeDiameterFilterProps) {
+  const [isTreeDiameterFilterExpanded, setIsTreeDiameterExpanded] = useState(false)
+  const [isAnyValueForAnySize, setIsValueForAnySize] = useState(false)
+
+  const toggleIsTreeDiameterFilterExpanded = () => {
+    setIsTreeDiameterExpanded(!isTreeDiameterFilterExpanded)
+  }
+
+  const setTreeDiameterSelectedStatus = () => {
+    const filterSearchParams = new URLSearchParams(window.location.search)
+    const urlMinDbh = filterSearchParams.get('min_dbh')
+    const urlMaxDbh = filterSearchParams.get('max_dbh')
+
+    setIsValueForAnySize(!!urlMinDbh || !!urlMaxDbh)
+  }
+
+  const handleSizeChange = ({ event, urlParamName }: handleSizeChangeProps) => {
+    const { value } = event.target
+    const isValue = value !== ''
+
+    if (isValue) {
+      setIsValueForAnySize(true)
+      setSearchParametersAndUpdateTrees({
+        [urlParamName]: value,
+      } as unknown as SharableUrlParameters)
+    }
+    if (!isValue) {
+      clearSearchParameterTypeAndUpdateTrees(urlParamName)
+
+      setTreeDiameterSelectedStatus()
+    }
+  }
+
+  const handleMinSizeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    handleSizeChange({ event, urlParamName: 'min_dbh' })
+  }
+
+  const handleMaxSizeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    handleSizeChange({ event, urlParamName: 'max_dbh' })
+  }
+
+  return (
+    <>
+      <RowAlignItemsCenter>
+        <ButtonExpandCollapse
+          onClick={toggleIsTreeDiameterFilterExpanded}
+          isExpanded={isTreeDiameterFilterExpanded}
+        />
+        <CifFormControlLabel
+          label="Tree Diameter (DBH)"
+          control={<Checkbox checked={isAnyValueForAnySize} />}
+        />
+      </RowAlignItemsCenter>
+      <Collapse in={isTreeDiameterFilterExpanded}>
+        <CifFormControlLabelIndented
+          label="Min Size (cm)"
+          control={
+            <TextField type="number" inputProps={{ min: 0 }} onChange={handleMinSizeChange} />
+          }
+        />
+        <CifFormControlLabelIndented
+          label="Max Size (cm)"
+          control={
+            <TextField type="number" inputProps={{ min: 0 }} onChange={handleMaxSizeChange} />
+          }
+        />
+      </Collapse>
+    </>
+  )
+}

--- a/src/components/customMuiFormComponents.tsx
+++ b/src/components/customMuiFormComponents.tsx
@@ -8,16 +8,22 @@ import {
   styled,
 } from '@mui/material'
 import { theme } from '../globalStyles/theme'
+import { themeMui } from '../globalStyles/themeMui'
 
 const CustomStyleFormControlLabel = styled(FormControlLabel)`
   margin: 0;
   display: flex;
   justify-content: space-between;
   width: 100%;
+  margin-bottom: ${themeMui.spacing(1)};
   &:focus-within,
   &:hover {
     background-color: ${theme.color.primary8Percent};
   }
+`
+
+const CustomStyleFormControlLabelIndented = styled(CustomStyleFormControlLabel)`
+  padding-left: 24px;
 `
 
 const CustomStyleListItem = styled(ListItem)`
@@ -26,6 +32,10 @@ const CustomStyleListItem = styled(ListItem)`
 
 export function CifFormControlLabel(props: FormControlLabelProps) {
   return <CustomStyleFormControlLabel labelPlacement="start" {...props} />
+}
+
+export function CifFormControlLabelIndented(props: FormControlLabelProps) {
+  return <CustomStyleFormControlLabelIndented labelPlacement="start" {...props} />
 }
 
 export function CifList(props: ListProps) {

--- a/src/types/topLevelAppTypes.ts
+++ b/src/types/topLevelAppTypes.ts
@@ -7,6 +7,8 @@ export interface SharableUrlParameters extends URLSearchParams {
   max_lng?: string
   common_species?: string[]
   cities?: string[]
+  max_dbh?: string
+  min_dbh?: string
 }
 
 export interface TreeProperties {


### PR DESCRIPTION
Hey @kaelaspark 

This project is very limited in time and budget, so I have been skipping some proccess things (like detailed tickets and how much info to put in a PR). I think you might still be interested in the PRs to help keep up the momentum with your react learnings. 

for context and to save time, this is the working app https://glittery-flan-51d119.netlify.app/. This change adds some more inputs for tree diameter to the filter and also sneaks some input margins in. 
