### PR TITLE
fix, add diameter to individual tree view

### DIFF
--- a/src/components/Map/TreeMetadata.tsx
+++ b/src/components/Map/TreeMetadata.tsx
@@ -27,7 +27,7 @@ export function TreeMetadata({ treeProperties }: TreeMetadataProps) {
     'Common Genus': commonGenus,
     'Common Species': commonSpecies,
     'Cultivar Name': cultivarName,
-    'DBH (cm)': diameter,
+    'DBH (DHP) (CM)': diameter,
     Address: address,
     City: city,
   } = treeProperties
@@ -46,7 +46,7 @@ export function TreeMetadata({ treeProperties }: TreeMetadataProps) {
         </tr>
         <tr>
           <th>Diameter (DBH)</th>
-          <td>{diameter ? <>{diameter}cm</> : null}</td>
+          <td>{diameter ? <>{diameter} cm</> : null}</td>
         </tr>
         <tr>
           <th>Botanical Name Genus</th>

--- a/src/types/topLevelAppTypes.ts
+++ b/src/types/topLevelAppTypes.ts
@@ -17,7 +17,7 @@ export interface TreeProperties {
   'Common Genus': string
   'Common Species': string
   'Cultivar Name': string
-  'DBH (cm)': number
+  'DBH (DHP) (CM)': number
   Address: string
   City: string
   Id: string


### PR DESCRIPTION
This PR...

Closes None

## Changes

- fixes diameter so that it shows up in the individual tree view. necessary especially with the new diameter filter so people can see it's working.

## Screenshots/ animated GIFs (optional)

<img width="1002" alt="Screen Shot 2023-06-02 at 10 06 30 AM" src="https://github.com/sparkgeo/cif-urban-forest-webapp/assets/19381236/210c48ef-3755-419d-b5ac-e1183dcd3545">

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Steps To Test

1. Run the app, zoom into an individual tree and check if diameter is being shown or not. 

### Expected Results
