### PR TITLE
debounce user-triggered api calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.12.1",
     "axios": "^1.3.6",
+    "lodash": "^4.17.21",
     "mapbox-gl": "npm:empty-npm-package@1.0.0",
     "maplibre-gl": "^2.4.0",
     "react": "^18.2.0",
@@ -27,6 +28,7 @@
     "vite-plugin-svgr": "^2.4.0"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.195",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@typescript-eslint/eslint-plugin": "^5.59.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { CircularProgress, Snackbar, ThemeProvider } from '@mui/material'
-import { useEffect, useState } from 'react'
+import { debounce } from 'lodash'
+import { useCallback, useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import axios from 'axios'
 import styled from '@emotion/styled'
@@ -87,6 +88,9 @@ export function App() {
       })
   }
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const debouncedUpdateTrees = useCallback(debounce(updateTrees, 750), [])
+
   const clearSearchParameterTypeAndUpdateTrees = (paramName: string) => {
     // we cant trust react router's searchParams state,
     // so we grab url params from window
@@ -96,7 +100,7 @@ export function App() {
     // because it doesnt cacuse the app to refresh like writing
     //  to window.location.search would
     setSearchParameters(newSearchParameters)
-    updateTrees()
+    debouncedUpdateTrees()
   }
 
   const setSearchParametersAndUpdateTrees = (newParameters: SharableUrlParameters) => {
@@ -133,7 +137,7 @@ export function App() {
     // to window.location.search would
     setSearchParameters(updatedUrlParameters, { replace: true })
 
-    updateTrees()
+    debouncedUpdateTrees()
   }
 
   const sideBar = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -803,6 +803,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/lodash@^4.14.195":
+  version "4.14.195"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.195.tgz#bafc975b252eb6cea78882ce8a7b6bf22a6de632"
+  integrity sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==
+
 "@types/mapbox-gl@^2.6.0":
   version "2.7.11"
   resolved "https://registry.yarnpkg.com/@types/mapbox-gl/-/mapbox-gl-2.7.11.tgz#c9b9ed2ed24970aeef947609fdfcfcf826a3aa49"
@@ -2372,6 +2377,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
This PR...

reduces api calls that are the result of user input events. Eg, if a user rapidly clicks the tree diameter number up, the api will only be called every 750ms



## Steps To Test

1. load the app
2. open dev tools and go to the network tab
3. go to a tree diameter input
4. rapidly increase the number using the arrow key in the input


### Expected Results
The `trees/search` endpoint for the api should be called waaaay less times than you click
